### PR TITLE
fix the " or exit " command and output redirection on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,15 +216,15 @@ SPROJECT_BUILD_SYSTEM_PATH="${SPROJECT_ROOT}/build_system"
 NBS_PATH="${SPROJECT_ROOT}/utilities/norlab-build-system"
 
 # ....Load environment variables from file..............................................
-cd "${SPROJECT_BUILD_SYSTEM_PATH}" || exit
+cd "${SPROJECT_BUILD_SYSTEM_PATH}" || exit 1
 set -o allexport && source .env && set +o allexport
 
 # ....Source NBS dependencies...........................................................
-cd "${NBS_PATH}" || exit
+cd "${NBS_PATH}" || exit 1
 source import_norlab_build_system_lib.bash
 
 # ====begin=============================================================================
-cd "${NBS_PATH}/src/utility_scripts" || exit
+cd "${NBS_PATH}/src/utility_scripts" || exit 1
 
 DOTENV_BUILD_MATRIX_REALPATH=${SPROJECT_BUILD_SYSTEM_PATH}/.env.build_matrix.dependencies
 

--- a/import_norlab_build_system_lib.bash
+++ b/import_norlab_build_system_lib.bash
@@ -22,7 +22,7 @@ function nbs::source_lib(){
   _REPO_ROOT="$(dirname "${_PATH_TO_SCRIPT}")"
 
   # ....Load environment variables from file.......................................................
-  cd "${_REPO_ROOT}" || exit
+  cd "${_REPO_ROOT}" || exit 1
   set -o allexport
   source .env.nbs
   set +o allexport
@@ -37,17 +37,17 @@ function nbs::source_lib(){
   source "import_norlab_shell_script_tools_lib.bash"
 
   # ....Source NBS functions.......................................................................
-  cd "${NBS_PATH}/src/function_library/build_tools" || exit
+  cd "${NBS_PATH}/src/function_library/build_tools" || exit 1
   for each_file in "$(pwd)"/*.bash ; do
       source "${each_file}"
   done
 
-  cd "${NBS_PATH}/src/function_library/container_tools" || exit
+  cd "${NBS_PATH}/src/function_library/container_tools" || exit 1
   for each_file in "$(pwd)"/*.bash ; do
       source "${each_file}"
   done
 
-  cd "${NBS_PATH}/src/function_library/dev_tools" || exit
+  cd "${NBS_PATH}/src/function_library/dev_tools" || exit 1
   for each_file in "$(pwd)"/*.bash ; do
       source "${each_file}"
   done

--- a/install_scripts/nbs_create_multiarch_docker_builder.bash
+++ b/install_scripts/nbs_create_multiarch_docker_builder.bash
@@ -16,7 +16,7 @@ function nbs::create_multiarch_docker_builder() {
   NBS_PATH=$(git rev-parse --show-toplevel)
 
   # ....Load environment variables from file.......................................................
-  cd "${NBS_PATH}" || exit
+  cd "${NBS_PATH}" || exit 1
   set -o allexport
   source .env.nbs
   set +o allexport

--- a/install_scripts/nbs_install_docker_tools.bash
+++ b/install_scripts/nbs_install_docker_tools.bash
@@ -17,7 +17,7 @@ function nbs::install_docker_tools() {
   NBS_PATH=$(git rev-parse --show-toplevel)
 
   # ....Load environment variables from file.......................................................
-  cd "${NBS_PATH}" || exit
+  cd "${NBS_PATH}" || exit 1
   set -o allexport
   source .env.nbs
   set +o allexport

--- a/src/utility_scripts/nbs_execute_compose_over_build_matrix.bash
+++ b/src/utility_scripts/nbs_execute_compose_over_build_matrix.bash
@@ -46,7 +46,7 @@
 
 # ....Pre-condition................................................................................
 if [[ "$(basename "$(pwd)")" != "utility_scripts" ]]; then
-  echo -e "\n[\033[1;31mERROR\033[0m] 'nbs_execute_compose_over_build_matrix.bash' script must be executed from the 'norlab-build-system/src/utility_scripts/' directory!\n Curent working directory is '$(pwd)'"
+  echo -e "\n[\033[1;31mERROR\033[0m] 'nbs_execute_compose_over_build_matrix.bash' script must be executed from the 'norlab-build-system/src/utility_scripts/' directory!\n Curent working directory is '$(pwd)'" 1>&2
   echo '(press any key to exit)'
   read -r -n 1
   exit 1

--- a/src/utility_scripts/nbs_install_python_dev_tools.bash
+++ b/src/utility_scripts/nbs_install_python_dev_tools.bash
@@ -9,7 +9,7 @@ set -e
 
 # ....Pre-condition................................................................................
 if [[ "$(basename "$(pwd)")" != "utility_scripts" ]]; then
-  echo -e "\n[\033[1;31mERROR\033[0m] 'nbs_install_python_dev_tools.bash' script must be executed from the 'norlab-build-system/src/utility_scripts/' directory!\n Curent working directory is '$(pwd)'"
+  echo -e "\n[\033[1;31mERROR\033[0m] 'nbs_install_python_dev_tools.bash' script must be executed from the 'norlab-build-system/src/utility_scripts/' directory!\n Curent working directory is '$(pwd)'" 1>&2
   echo '(press any key to exit)'
   read -r -n 1
   exit 1

--- a/src/utility_scripts/nbs_run_all_test_and_dryrun_in_directory.bash
+++ b/src/utility_scripts/nbs_run_all_test_and_dryrun_in_directory.bash
@@ -24,7 +24,7 @@ MSG_END_FORMAT="\033[0m"
 function nbs::run_all_script_in_directory(){
   local _TMP_CWD
   _TMP_CWD=$(pwd)
-  cd "${SCRIPT_DIR_PATH}" || exit
+  cd "${SCRIPT_DIR_PATH}" || exit 1
 
   declare -a FILE_NAME
 

--- a/tests/tests_bats/test_import_lib.bats
+++ b/tests/tests_bats/test_import_lib.bats
@@ -26,7 +26,7 @@ if [[ -d ${BATS_HELPER_PATH} ]]; then
   load "${SRC_CODE_PATH}/${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/bats_helper_functions"
   #load "${BATS_HELPER_PATH}/bats-detik/load" # << Kubernetes support
 else
-  echo -e "\n[\033[1;31mERROR\033[0m] $0 path to bats-core helper library unreachable at \"${BATS_HELPER_PATH}\"!"
+  echo -e "\n[\033[1;31mERROR\033[0m] $0 path to bats-core helper library unreachable at \"${BATS_HELPER_PATH}\"!" 1>&2
   echo '(press any key to exit)'
   read -r -n 1
   exit 1
@@ -48,7 +48,7 @@ setup_file() {
 
 # executed before each test
 setup() {
-  cd "$TESTED_FILE_PATH" || exit
+  cd "$TESTED_FILE_PATH" || exit 1
 }
 
 # ====Teardown=====================================================================================

--- a/tests/tests_bats/tests_function_library/tests_build_tools/test_execute_compose.bats
+++ b/tests/tests_bats/tests_function_library/tests_build_tools/test_execute_compose.bats
@@ -26,7 +26,7 @@ if [[ -d ${BATS_HELPER_PATH} ]]; then
   load "${SRC_CODE_PATH}/${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/bats_helper_functions"
   #load "${BATS_HELPER_PATH}/bats-detik/load" # << Kubernetes support
 else
-  echo -e "\n[\033[1;31mERROR\033[0m] $0 path to bats-core helper library unreachable at \"${BATS_HELPER_PATH}\"!"
+  echo -e "\n[\033[1;31mERROR\033[0m] $0 path to bats-core helper library unreachable at \"${BATS_HELPER_PATH}\"!" 1>&2
   echo '(press any key to exit)'
   read -r -n 1
   exit 1
@@ -50,7 +50,7 @@ setup_file() {
 # executed before each test
 setup() {
   source import_norlab_build_system_lib.bash
-  cd "${SRC_CODE_PATH}/$TESTED_FILE_PATH" || exit
+  cd "${SRC_CODE_PATH}/$TESTED_FILE_PATH" || exit 1
 }
 
 # ====Teardown=====================================================================================
@@ -79,7 +79,7 @@ PATH_TO_DOCKERFILE="${SRC_CODE_PATH}"/build_system_templates/docker-compose.depe
 # ....Test fct integration to script...............................................................
 @test "${TESTED_FILE} › function ${TESTED_FCT} › integration in nbs_execute_compose_over_build_matrix.bash › execute ok › expect pass" {
 
-  cd "${SRC_CODE_PATH}/src/utility_scripts/" || exit
+  cd "${SRC_CODE_PATH}/src/utility_scripts/" || exit 1
 
   DOTENV_BUILD_MATRIX="${SRC_CODE_PATH}"/build_system_templates/.env.build_matrix.dependencies.template
   run bash "nbs_execute_compose_over_build_matrix.bash" "${DOTENV_BUILD_MATRIX}" --fail-fast -- build

--- a/tests/tests_bats/tests_function_library/tests_container_tools/test_install_python_dev_tools.bats
+++ b/tests/tests_bats/tests_function_library/tests_container_tools/test_install_python_dev_tools.bats
@@ -26,7 +26,7 @@ if [[ -d ${BATS_HELPER_PATH} ]]; then
   load "${SRC_CODE_PATH}/${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/bats_helper_functions"
   #load "${BATS_HELPER_PATH}/bats-detik/load" # << Kubernetes support
 else
-  echo -e "\n[\033[1;31mERROR\033[0m] $0 path to bats-core helper library unreachable at \"${BATS_HELPER_PATH}\"!"
+  echo -e "\n[\033[1;31mERROR\033[0m] $0 path to bats-core helper library unreachable at \"${BATS_HELPER_PATH}\"!" 1>&2
   echo '(press any key to exit)'
   read -r -n 1
   exit 1
@@ -49,7 +49,7 @@ setup_file() {
 # executed before each test
 setup() {
   source import_norlab_build_system_lib.bash
-  cd "$TESTED_FILE_PATH" || exit
+  cd "$TESTED_FILE_PATH" || exit 1
 }
 
 # ====Teardown=====================================================================================

--- a/tests/tests_bats/tests_utility_script/test_execute_compose_over_build_matrix.bats
+++ b/tests/tests_bats/tests_utility_script/test_execute_compose_over_build_matrix.bats
@@ -26,7 +26,7 @@ if [[ -d ${BATS_HELPER_PATH} ]]; then
   load "${SRC_CODE_PATH}/${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/bats_helper_functions"
   #load "${BATS_HELPER_PATH}/bats-detik/load" # << Kubernetes support
 else
-  echo -e "\n[\033[1;31mERROR\033[0m] $0 path to bats-core helper library unreachable at \"${BATS_HELPER_PATH}\"!"
+  echo -e "\n[\033[1;31mERROR\033[0m] $0 path to bats-core helper library unreachable at \"${BATS_HELPER_PATH}\"!" 1>&2
   echo '(press any key to exit)'
   read -r -n 1
   exit 1
@@ -55,7 +55,7 @@ setup() {
   cd "${SRC_CODE_PATH}"
   source import_norlab_build_system_lib.bash
 
-  cd "$TESTED_FILE_PATH" || exit
+  cd "$TESTED_FILE_PATH" || exit 1
 }
 
 # ====Teardown=====================================================================================

--- a/tests/tests_bats/tests_utility_script/test_install_docker_tools_and_buildx_create_script.bats
+++ b/tests/tests_bats/tests_utility_script/test_install_docker_tools_and_buildx_create_script.bats
@@ -26,7 +26,7 @@ if [[ -d ${BATS_HELPER_PATH} ]]; then
   load "${SRC_CODE_PATH}/${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/bats_helper_functions"
   #load "${BATS_HELPER_PATH}/bats-detik/load" # << Kubernetes support
 else
-  echo -e "\n[\033[1;31mERROR\033[0m] $0 path to bats-core helper library unreachable at \"${BATS_HELPER_PATH}\"!"
+  echo -e "\n[\033[1;31mERROR\033[0m] $0 path to bats-core helper library unreachable at \"${BATS_HELPER_PATH}\"!" 1>&2
   echo '(press any key to exit)'
   read -r -n 1
   exit 1
@@ -49,7 +49,7 @@ setup_file() {
 
 # executed before each test
 setup() {
-  cd "$TESTED_FILE_PATH" || exit
+  cd "$TESTED_FILE_PATH" || exit 1
 }
 
 # ====Teardown=====================================================================================

--- a/tests/tests_bats/tests_utility_script/test_nbs_install_python_dev_tools.bats
+++ b/tests/tests_bats/tests_utility_script/test_nbs_install_python_dev_tools.bats
@@ -26,7 +26,7 @@ if [[ -d ${BATS_HELPER_PATH} ]]; then
   load "${SRC_CODE_PATH}/${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/bats_helper_functions"
   #load "${BATS_HELPER_PATH}/bats-detik/load" # << Kubernetes support
 else
-  echo -e "\n[\033[1;31mERROR\033[0m] $0 path to bats-core helper library unreachable at \"${BATS_HELPER_PATH}\"!"
+  echo -e "\n[\033[1;31mERROR\033[0m] $0 path to bats-core helper library unreachable at \"${BATS_HELPER_PATH}\"!" 1>&2
   echo '(press any key to exit)'
   read -r -n 1
   exit 1
@@ -48,7 +48,7 @@ setup_file() {
 
 # executed before each test
 setup() {
-  cd "$TESTED_FILE_PATH" || exit
+  cd "$TESTED_FILE_PATH" || exit 1
 }
 
 # ====Teardown=====================================================================================


### PR DESCRIPTION
issue NMO-457

- best practice: `<command> || exit` need to change to  `<command> || exit 1` so that it return an error on logic faillure
- best practice: output redirection need to be from stdout to stder on error