### PR TITLE
Add docker hub release logic

### DIFF
--- a/build_system_templates/docker-compose.project_core.yaml
+++ b/build_system_templates/docker-compose.project_core.yaml
@@ -36,30 +36,30 @@ services:
       platforms:
         - "linux/arm64"
 
-#  # ====Dockerhub release image====================================================================
-#  release:
-#    image: ${NBS_DOCKERHUB_NAMESPACE:?err}/${NBS_REPOSITORY_NAME}:${NBS_IMAGE_TAG:?err}
-#    container_name: ${NBS_REPOSITORY_NAME}
-#    build:
-#      context: ..
-#      # (Priority) ToDo: change path to dockerfile
-#      dockerfile: ${NBS_SUPERPROJECT_BUILD_SYSTEM_DIR:?err}/nbs_container/project-core/Dockerfile.project.hub_release
-#      platforms:
-#        - "linux/amd64"
-#        - "linux/arm64/v8"
-#      no_cache: true
-#      args:
-#        PROJECT_HUB: ${NBS_DOCKERHUB_NAMESPACE}
-#        BASE_IMAGE: ${NBS_REPOSITORY_NAME}-dependencies
-#        BASE_IMAGE_TAG: ${NBS_IMAGE_TAG}
-#        IS_TEAMCITY_RUN: ${IS_TEAMCITY_RUN}
-#        REPOSITORY_VERSION: ${REPOSITORY_VERSION:?err}
-#        CMAKE_BUILD_TYPE: 'Release'
-##        INSTALL_SCRIPT_FLAG: '--compile-test --generate-doc'
-#    tty: true
-#    stdin_open: true
-#    init: true  # Propagate exit code (See remark in task NMO-266)
-#    depends_on:
-#      - dependencies
+  # ====Dockerhub release image====================================================================
+  release:
+    image: ${NBS_DOCKERHUB_NAMESPACE:?err}/${NBS_REPOSITORY_NAME}:${NBS_IMAGE_TAG:?err}
+    container_name: ${NBS_REPOSITORY_NAME}
+    build:
+      context: ..
+      # (Priority) ToDo: change path to dockerfile
+      dockerfile: ${NBS_SUPERPROJECT_BUILD_SYSTEM_DIR:?err}/nbs_container/project-core/Dockerfile.project.hub_release
+      platforms:
+        - "linux/amd64"
+        - "linux/arm64/v8"
+      no_cache: true
+      args:
+        PROJECT_HUB: ${NBS_DOCKERHUB_NAMESPACE}
+        BASE_IMAGE: ${NBS_REPOSITORY_NAME}-dependencies
+        BASE_IMAGE_TAG: ${NBS_IMAGE_TAG}
+        IS_TEAMCITY_RUN: ${IS_TEAMCITY_RUN}
+        REPOSITORY_VERSION: ${REPOSITORY_VERSION:?err}
+        CMAKE_BUILD_TYPE: 'Release'
+        INSTALL_SCRIPT_FLAG: '--compile-test --generate-doc'
+    tty: true
+    stdin_open: true
+    init: true  # Propagate exit code (See remark in task NMO-266)
+    depends_on:
+      - dependencies
 
 

--- a/build_system_templates/installer/nbs_cmake_install_ubuntu.bash
+++ b/build_system_templates/installer/nbs_cmake_install_ubuntu.bash
@@ -1,0 +1,280 @@
+#!/bin/bash -i
+# =================================================================================================
+#
+# Install project via cmake
+#
+# Usage:
+#   $ bash nbs_cmake_install_ubuntu.bash [<optional flag>]
+#
+# Arguments:
+#   --install-path </dir/abs/path/>     The directory where to install project (absolute path)
+#                                           (default location defined in the .env)
+#   --repository-version 1.0.7         Install project release tag version (default to master branch latest)
+#   --compile-test                      Compile the project unit-test
+#   --generate-doc                      Generate the project doxygen documentation
+#                                           in /usr/local/share/doc/<project>/api/html/index.html
+#   --cmake-build-type RelWithDebInfo   The type of cmake build: None Debug Release RelWithDebInfo MinSizeRel
+#                                           (default to RelWithDebInfo)
+#   --build-system-CI-install           Set special configuration for CI/CD build system:
+#                                           skip the git clone install step and assume the repository is already
+#                                           pulled and checkout on the desired branch
+#   --test-run                          CI/CD build system Test-run mode
+#   -h, --help                          Get help
+#
+# Global
+#   - Read the array APPEND_TO_CMAKE_FLAG
+#
+#     Usage:
+#      $ export APPEND_TO_CMAKE_FLAG=( -D CMAKE_INSTALL_PREFIX=/opt ) \
+#           && source nbs_cmake_install_ubuntu.bash
+#
+# Note:
+#   - this script required package: g++, make, cmake, build-essential, git and all project dependencies
+#
+# =================================================================================================
+
+set -e # Note: we want the installer to always fail-fast (it wont affect the build system policy)
+
+declare -a CMAKE_FLAGS
+
+CALLER_NAME="$(basename "$0" )"
+
+# ....Default......................................................................................
+REPOSITORY_VERSION='latest'
+BUILD_TESTS_FLAG=OFF
+PROJECT_BUILD_DOXYGEN_FLAG=OFF
+BUILD_SYSTEM_CI_INSTALL=FALSE
+CMAKE_BUILD_TYPE=RelWithDebInfo
+
+# skip GUI dialog by setting everything to default
+export DEBIAN_FRONTEND=noninteractive
+
+# ....Project root logic...........................................................................
+TMP_CWD=$(pwd)
+
+PROJECT_PATH=$(git rev-parse --show-toplevel)
+cd "${PROJECT_PATH}/${NBS_SUPERPROJECT_BUILD_SYSTEM_DIR}" || exit
+
+# ....Load environment variables from file.........................................................
+set -o allexport
+source .env
+set +o allexport
+
+# ....Helper function..............................................................................
+# import shell functions from utilities library
+N2ST_PATH=${N2ST_PATH:-"${PROJECT_PATH}/${NBS_SUPERPROJECT_BUILD_SYSTEM_DIR}/utilities/norlab-build-system/utilities/norlab-shell-script-tools"}
+source "${N2ST_PATH}/import_norlab_shell_script_tools_lib.bash"
+
+# Set environment variable IMAGE_ARCH_AND_OS
+cd "${N2ST_PATH}"/src/utility_scripts/ && source "which_architecture_and_os.bash"
+
+function print_help_in_terminal() {
+  echo -e "\$ ${0} [<optional argument>]
+
+  \033[1m<optional argument>:\033[0m
+    --install-path </dir/abs/path/>       The directory where to install (absolute path)
+                                            (default location ${MSG_DIMMED_FORMAT}${NBS_LIB_INSTALL_PATH:?err}${MSG_END_FORMAT})
+    --repository-version 1.0.7            Install release tag version (default to master branch latest)
+    --compile-test                        Compile the unit-test
+                                            in ${MSG_DIMMED_FORMAT}${NBS_LIB_INSTALL_PATH}/${NBS_REPOSITORY_NAME:?err}/build${MSG_END_FORMAT}
+    --generate-doc                        Generate the project doxygen documentation
+                                            in ${MSG_DIMMED_FORMAT}/usr/local/share/doc/${NBS_REPOSITORY_NAME}/api/html/index.html${MSG_END_FORMAT}
+    --cmake-build-type RelWithDebInfo     The type of cmake build: None Debug Release RelWithDebInfo MinSizeRel
+    --build-system-CI-install             Set special configuration for CI/CD build system:
+                                            skip the git clone install step and assume the repository is already
+                                            pulled and checkout on the desired branch
+    --test-run                            CI/CD build system Test-run mode
+    -h, --help                            Get help
+
+  Global
+    - Read the array APPEND_TO_CMAKE_FLAG
+
+      Usage:
+       $ export APPEND_TO_CMAKE_FLAG=( -D CMAKE_INSTALL_PREFIX=/opt ) && source nbs_cmake_install_ubuntu.bash
+
+  "
+}
+
+# ====Begin========================================================================================
+SHOW_SPLASH_ILU="${SHOW_SPLASH_ILU:-true}"
+
+if [[ "${SHOW_SPLASH_ILU}" == 'true' ]]; then
+  norlab_splash "${NBS_SPLASH_NAME:?err}" "https://github.com/${NBS_REPOSITORY_DOMAIN:?err}/${NBS_REPOSITORY_NAME:?err}"
+fi
+
+print_formated_script_header "${CALLER_NAME} (${IMAGE_ARCH_AND_OS:?err})" "${MSG_LINE_CHAR_INSTALLER}"
+
+
+# ....Script command line flags....................................................................
+while [ $# -gt 0 ]; do
+
+  case $1 in
+  --install-path)
+    unset NBS_LIB_INSTALL_PATH
+    NBS_LIB_INSTALL_PATH="${2}"
+    shift # Remove argument (--install-path)
+    shift # Remove argument value
+    ;;
+  --repository-version)
+    REPOSITORY_VERSION="${2}"
+    shift # Remove argument (--repository-version)
+    shift # Remove argument value
+    ;;
+  --cmake-build-type)
+    CMAKE_BUILD_TYPE="${2}"
+    shift # Remove argument (--cmake-build-type)
+    shift # Remove argument value
+    ;;
+  --compile-test)
+    BUILD_TESTS_FLAG=ON
+    shift
+    ;;
+  --generate-doc)
+    PROJECT_BUILD_DOXYGEN_FLAG=ON
+    shift
+    ;;
+  --build-system-CI-install)
+    BUILD_SYSTEM_CI_INSTALL=TRUE
+    shift
+    ;;
+  --test-run)
+    TEST_RUN=true
+    shift
+    ;;
+  -h | --help)
+    print_help_in_terminal
+    exit
+    ;;
+  --) # no more option
+    shift
+    break
+    ;;
+  --?* | -?*)
+    echo "$0: $1: unrecognized option" >&2 # Note: '>&2' = print to stderr
+    shift
+    ;;
+  *) # Default case
+    break
+    ;;
+  esac
+
+done
+
+
+# ....Cmake flags..................................................................................
+CMAKE_FLAGS=( -D CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" -D PROJECT_BUILD_TESTS="${BUILD_TESTS_FLAG}" -D PROJECT_BUILD_DOXYGEN="${PROJECT_BUILD_DOXYGEN_FLAG}" "${APPEND_TO_CMAKE_FLAG[@]}" )
+
+# (CRITICAL) ToDo: validate >> PROJECT_BUILD_DOXYGEN install dir
+
+# Note:
+#   - Previously use intall flag quick-hack to work around the install issue.
+#   - Keep it here as futur reference
+#  -D PROJECT_INSTALL_DIR="${NBS_LIB_INSTALL_PATH}/<project>" \
+
+# ----Install steps--------------------------------------------------------------------------------
+teamcity_service_msg_blockOpened "Install ${NBS_REPOSITORY_NAME}"
+
+mkdir -p "${NBS_LIB_INSTALL_PATH}"
+print_msg "Directories (pre project install)$(tree -L 2 "${NBS_LIB_INSTALL_PATH}")"
+cd "${NBS_LIB_INSTALL_PATH}"
+
+# ....Repository cloning step......................................................................
+if [[ ${BUILD_SYSTEM_CI_INSTALL} == FALSE ]]; then
+
+  if [[ -d ${NBS_REPOSITORY_NAME}/.git ]]; then
+    print_msg_error_and_exit "${MSG_DIMMED_FORMAT}${NBS_REPOSITORY_NAME}${MSG_END_FORMAT} source code was already checkout in the specified install directory ${MSG_DIMMED_FORMAT}${NBS_LIB_INSTALL_PATH}/${MSG_END_FORMAT}, specify an other one using ${MSG_DIMMED_FORMAT}--install-path </install/dir/path/>${MSG_END_FORMAT}."
+  fi
+
+  git clone https://github.com/"${NBS_REPOSITORY_DOMAIN}"/"${NBS_REPOSITORY_NAME}".git
+
+  if [[ "${REPOSITORY_VERSION}" != 'latest' ]]; then
+    cd "${NBS_REPOSITORY_NAME}"
+
+    git fetch --tags
+    git tag --list
+
+    ## Remove prefix 'v' from version tag
+    #GITHUB_TAG="${REPOSITORY_VERSION/v/}"
+    GITHUB_TAG="${REPOSITORY_VERSION}"
+
+    git checkout tags/"${GITHUB_TAG}"
+
+    print_msg "Repository checkout at tag $(git symbolic-ref -q --short HEAD || git describe --tags --exact-match)"
+  fi
+fi
+
+cd "${NBS_LIB_INSTALL_PATH}/${NBS_REPOSITORY_NAME}"
+mkdir -p build && cd build
+
+# ....Cmake install step...........................................................................
+teamcity_service_msg_compilationStarted "cmake"
+
+print_msg "Execute ${MSG_DIMMED_FORMAT}
+cmake ${CMAKE_FLAGS[*]} ${NBS_LIB_INSTALL_PATH}/${NBS_REPOSITORY_NAME}
+${MSG_END_FORMAT}"
+
+if [[ $TEST_RUN  == true ]]; then
+  print_msg "Test-run mode: Skipping cmake"
+  BUILD_EXIT_CODE=0
+  INSTALL_EXIT_CODE=0
+else
+  cmake "${CMAKE_FLAGS[@]}" "${NBS_LIB_INSTALL_PATH}/${NBS_REPOSITORY_NAME}"
+
+  BUILD_EXIT_CODE=$?
+
+  make -j $(nproc)
+  sudo make install
+
+  INSTALL_EXIT_CODE=$?
+
+  if [[ ${PROJECT_BUILD_DOXYGEN_FLAG} = ON ]]; then
+      make doc
+  fi
+
+  ## List all CMake build options and their default values
+  ##   ref: https://stackoverflow.com/questions/16851084/how-to-list-all-cmake-build-options-and-their-default-values
+  #cmake -LAH
+fi
+
+print_msg "Directories (post ${NBS_REPOSITORY_NAME} install)$(tree -L 2 ${NBS_LIB_INSTALL_PATH})"
+
+teamcity_service_msg_compilationFinished
+teamcity_service_msg_blockClosed
+
+# ....Install/build feedback.......................................................................
+SUCCESS_MSG="${NBS_REPOSITORY_NAME} installed successfully at ${MSG_DIMMED_FORMAT}${NBS_LIB_INSTALL_PATH}/${NBS_REPOSITORY_NAME}${MSG_END_FORMAT}"
+FAILURE_MSG="${NBS_REPOSITORY_NAME} installer exited with error"
+
+if [[ ${IS_TEAMCITY_RUN} == true ]]; then
+  # Report message to build log
+  if [[ ${BUILD_EXIT_CODE} == 0 ]] && [[ ${INSTALL_EXIT_CODE} == 0 ]]; then
+    echo -e "##teamcity[message text='${MSG_BASE_TEAMCITY} ${SUCCESS_MSG}' status='NORMAL']"
+  else
+    if [[ ${BUILD_EXIT_CODE} != 0 ]]; then
+      echo -e "##teamcity[message text='${MSG_BASE_TEAMCITY} ${FAILURE_MSG}' errorDetails='$BUILD_EXIT_CODE' status='ERROR']"
+      print_formated_script_footer "${CALLER_NAME} (${IMAGE_ARCH_AND_OS})" "${MSG_LINE_CHAR_INSTALLER}"
+      exit $BUILD_EXIT_CODE
+    else
+      echo -e "##teamcity[message text='${MSG_BASE_TEAMCITY} ${FAILURE_MSG}' errorDetails='$INSTALL_EXIT_CODE' status='ERROR']"
+      print_formated_script_footer "${CALLER_NAME} (${IMAGE_ARCH_AND_OS})" "${MSG_LINE_CHAR_INSTALLER}"
+      exit $INSTALL_EXIT_CODE
+    fi
+  fi
+else
+  if [[ ${BUILD_EXIT_CODE} == 0 ]] && [[ ${INSTALL_EXIT_CODE} == 0 ]]; then
+    echo " " && print_msg_done "${SUCCESS_MSG}"
+  else
+    print_msg_error "${FAILURE_MSG}"
+    print_formated_script_footer "${CALLER_NAME} (${IMAGE_ARCH_AND_OS})" "${MSG_LINE_CHAR_INSTALLER}"
+    if [[ ${BUILD_EXIT_CODE} != 0 ]]; then
+      exit $BUILD_EXIT_CODE
+    else
+      exit $INSTALL_EXIT_CODE
+    fi
+  fi
+fi
+
+print_formated_script_footer "${CALLER_NAME} (${IMAGE_ARCH_AND_OS})" "${MSG_LINE_CHAR_INSTALLER}"
+
+# ====Teardown=====================================================================================
+cd "${TMP_CWD}"

--- a/build_system_templates/nbs_container/project-core/Dockerfile.project.ci_PR
+++ b/build_system_templates/nbs_container/project-core/Dockerfile.project.ci_PR
@@ -16,7 +16,6 @@ ENV NBS_REPOSITORY_NAME=${NBS_REPOSITORY_NAME:?'Build argument needs to be set a
 
 ARG CMAKE_BUILD_TYPE=RelWithDebInfo
 ARG INSTALL_SCRIPT_FLAG='--build-system-CI-install --compile-test'
-# Note: Those env variable are used in the entrypoint build version
 ENV CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 ENV INSTALL_SCRIPT_FLAG=${INSTALL_SCRIPT_FLAG}
 
@@ -26,7 +25,6 @@ ENV IS_TEAMCITY_RUN=${IS_TEAMCITY_RUN:-false}
 SHELL ["/bin/bash", "-c"]
 ARG DEBIAN_FRONTEND=noninteractive
 
-# ToDo: validate
 ENV TERM=${TERM:-"xterm-256color"}
 
 # ====Checkout repository==========================================================================
@@ -37,9 +35,18 @@ COPY . .
 
 # ====Check dependencies installed versions========================================================
 WORKDIR "${NBS_LIB_INSTALL_PATH}/${NBS_REPOSITORY_NAME}/${NBS_SUPERPROJECT_BUILD_SYSTEM_DIR}"
-
 RUN chmod +x ./nbs_container/project-core/entrypoint.bash
+RUN chmod +x ./installer/nbs_cmake_install_ubuntu.bash
 
+## (Priority) ToDo: add install logic here
+#WORKDIR "./installer"
+#RUN bash nbs_cmake_install_ubuntu.bash \
+#    --install-path ${NBS_LIB_INSTALL_PATH} \
+#    --repository-version ${REPOSITORY_VERSION} \
+#    --cmake-build-type ${CMAKE_BUILD_TYPE} \
+#    ${INSTALL_SCRIPT_FLAG}
+
+# (Priority) ToDo: add test logic here
 
 # ====End==========================================================================================
 ENTRYPOINT [ "./nbs_container/project-core/entrypoint.bash" ]

--- a/build_system_templates/nbs_container/project-core/Dockerfile.project.hub_release
+++ b/build_system_templates/nbs_container/project-core/Dockerfile.project.hub_release
@@ -1,0 +1,64 @@
+ARG PROJECT_HUB=norlabulaval
+ARG BASE_IMAGE=libnabo-dependencies-doc
+ARG BASE_IMAGE_TAG
+FROM ${PROJECT_HUB}/${BASE_IMAGE}:${BASE_IMAGE_TAG:?err} AS project-install
+
+LABEL org.opencontainers.image.authors="luc.coupal.1@ulaval.ca"
+
+ARG REPOSITORY_VERSION
+ENV REPOSITORY_VERSION=${REPOSITORY_VERSION:?'Build argument needs to be set and non-empty.'}
+LABEL libnabo.version="${REPOSITORY_VERSION}"
+
+
+ARG NBS_LIB_INSTALL_PATH
+ARG NBS_REPOSITORY_NAME
+ENV NBS_LIB_INSTALL_PATH=${NBS_LIB_INSTALL_PATH:?'Build argument needs to be set and non-empty.'}
+ENV NBS_REPOSITORY_NAME=${NBS_REPOSITORY_NAME:?'Build argument needs to be set and non-empty.'}
+
+ARG CMAKE_BUILD_TYPE=Release
+ARG INSTALL_SCRIPT_FLAG=""
+ENV CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+ENV INSTALL_SCRIPT_FLAG=${INSTALL_SCRIPT_FLAG}
+
+ARG IS_TEAMCITY_RUN
+ENV IS_TEAMCITY_RUN=${IS_TEAMCITY_RUN:-false}
+
+SHELL ["/bin/bash", "-c"]
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ====Build system related setup===================================================================
+WORKDIR "${NBS_LIB_INSTALL_PATH}/release-prep/"
+
+# Copy only the build system file for running the install and test scripts
+# Note: Logic to copy files from the checkout branch is handle by 'nabo_install_libnabo_ubuntu.bash' script
+COPY . .
+
+
+# ==== Build project checkout branch ==============================================================
+WORKDIR "./${NBS_SUPERPROJECT_BUILD_SYSTEM_DIR}/installer"
+
+## (Priority) ToDo: add install logic here
+# Note: Make sure to install in "${NBS_LIB_INSTALL_PATH}/<project name>/" as the "release-prep/"
+# directory is deleted at the end of this install step
+#RUN chmod +x nbs_cmake_install_ubuntu.bash
+#RUN bash nbs_cmake_install_ubuntu.bash \
+#    --install-path ${NBS_LIB_INSTALL_PATH} \
+#    --repository-version ${REPOSITORY_VERSION} \
+#    --cmake-build-type ${CMAKE_BUILD_TYPE} \
+#    ${INSTALL_SCRIPT_FLAG}
+
+RUN rm -rf "${NBS_LIB_INSTALL_PATH}/release-prep/"
+
+# ====End==========================================================================================
+FROM project-install AS project-release
+WORKDIR "${NBS_LIB_INSTALL_PATH}/${NBS_REPOSITORY_NAME}/${NBS_SUPERPROJECT_BUILD_SYSTEM_DIR}"
+
+COPY "./${NBS_SUPERPROJECT_BUILD_SYSTEM_DIR}/nbs_container/project-core/entrypoint.bash" "./nbs_container/project-core/entrypoint.bash"
+COPY "./${NBS_SUPERPROJECT_BUILD_SYSTEM_DIR}/.env" "./.env"
+
+RUN chmod +x ./nbs_container/project-core/entrypoint.bash
+RUN chmod +x ./.env
+
+WORKDIR "${NBS_LIB_INSTALL_PATH}/${NBS_REPOSITORY_NAME}"
+ENTRYPOINT [ "./${NBS_SUPERPROJECT_BUILD_SYSTEM_DIR}/nbs_container/project-core/entrypoint.bash" ]
+CMD [ "bash" ]

--- a/build_system_templates/nbs_container/project-core/entrypoint.bash
+++ b/build_system_templates/nbs_container/project-core/entrypoint.bash
@@ -9,17 +9,21 @@
 #   <any-cmd>      Optional command executed in a subprocess at the end of the entrypoint script.
 #
 
-ifconfig
+# ....Load environment variables from file.........................................................
+set -o allexport
+source "${NBS_LIB_INSTALL_PATH}/${NBS_REPOSITORY_NAME}/${NBS_SUPERPROJECT_BUILD_SYSTEM_DIR}/.env"
+set +o allexport
 
-cd "${NBS_LIB_INSTALL_PATH}"
+# ....Helper function..............................................................................
+source "${N2ST_PATH:?err}/import_norlab_shell_script_tools_lib.bash"
 
-pwd
-tree -L 1
+# ====Begin========================================================================================
+clear
 
-echo "dir size"
-du -h --max-depth=2
-echo
+norlab_splash "${NBS_SPLASH_NAME:?err}" "https://github.com/${NBS_REPOSITORY_DOMAIN:?err}/${NBS_REPOSITORY_NAME:?err}"
+
+#ifconfig
+pwd && tree -L 1
 
 # ====Continue=====================================================================================================
 exec "$@"
-

--- a/tests/tests_bats/tests_installer/test_build_system_cmake_installer.bats
+++ b/tests/tests_bats/tests_installer/test_build_system_cmake_installer.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+#
+# Usage in docker container
+#   $ REPO_ROOT=$(pwd) && RUN_TESTS_IN_DIR='tests'
+#   $ docker run -it --rm -v "$REPO_ROOT:/code" bats/bats:latest "$RUN_TESTS_IN_DIR"
+#
+#   Note: "/code" is the working directory in the bats official image
+#
+# bats-core ref:
+#   - https://bats-core.readthedocs.io/en/stable/tutorial.html
+#   - https://bats-core.readthedocs.io/en/stable/writing-tests.html
+#   - https://opensource.com/article/19/2/testing-bash-bats
+#       ↳ https://github.com/dmlond/how_to_bats/blob/master/test/build.bats
+#
+# Helper library: 
+#   - https://github.com/bats-core/bats-assert
+#   - https://github.com/bats-core/bats-support
+#   - https://github.com/bats-core/bats-file
+#
+
+BATS_HELPER_PATH=/usr/lib/bats
+if [[ -d ${BATS_HELPER_PATH} ]]; then
+  load "${BATS_HELPER_PATH}/bats-support/load"
+  load "${BATS_HELPER_PATH}/bats-assert/load"
+  load "${BATS_HELPER_PATH}/bats-file/load"
+  load "${SRC_CODE_PATH}/${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/bats_helper_functions"
+  #load "${BATS_HELPER_PATH}/bats-detik/load" # << Kubernetes support
+else
+  echo -e "\n[\033[1;31mERROR\033[0m] $0 path to bats-core helper library unreachable at \"${BATS_HELPER_PATH}\"!" 1>&2
+  echo '(press any key to exit)'
+  read -r -n 1
+  exit 1
+fi
+
+# ====Setup========================================================================================
+TESTED_FILE="nbs_cmake_install_ubuntu.bash"
+TESTED_FILE_PATH="./build_system_templates/installer"
+
+# executed once before starting the first test (valide for all test in that file)
+setup_file() {
+  BATS_DOCKER_WORKDIR=$(pwd) && export BATS_DOCKER_WORKDIR
+  export N2ST_PATH="$(git rev-parse --show-toplevel)/utilities/norlab-shell-script-tools"
+
+  # Uncomment the following for debug, the ">&3" is for printing bats msg to stdin
+#  pwd >&3 && tree -L 1 -a -hug >&3
+#  pwd >&3 && tree -L 2 -a ./build_system/utilities >&3
+#  printenv >&3
+}
+
+# executed before each test
+setup() {
+  echo "(Bats) Source project .env"
+  set -o allexport
+  source "${BATS_DOCKER_WORKDIR:?err}/build_system_templates/.env"
+  set +o allexport
+
+  cd "$TESTED_FILE_PATH" || exit 1
+}
+
+# ====Teardown=====================================================================================
+
+# executed after each test
+teardown() {
+  echo "(Bats) Reset install directory"
+  if [[ -d ${NBS_LIB_INSTALL_PATH}/dockerized-norlab-project-mock ]]; then
+    rm -rf "${NBS_LIB_INSTALL_PATH}/dockerized-norlab-project-mock"
+  fi
+
+#  bats_print_run_env_variable_on_error
+}
+
+## executed once after finishing the last test (valide for all test in that file)
+#teardown_file() {
+#}
+
+# ====Test casses==================================================================================
+# ....Build system install script..................................................................
+
+@test "Mock Project | run ${TESTED_FILE} (default) › expect pass" {
+#  skip "tmp debug" # ToDo: on task end >> delete this line ←
+  cd "${BATS_DOCKER_WORKDIR}"
+
+  run bash "./${TESTED_FILE_PATH}/$TESTED_FILE" --test-run
+
+  assert_success
+
+  assert_output --regexp .*"\[".*"DN-mock".*"\]".*"Install dockerized-norlab-project-mock"
+
+  assert_output --regexp .*"\[".*"DN-mock".*"\]".*"Execute".*"cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -D PROJECT_BUILD_TESTS=OFF -D PROJECT_BUILD_DOXYGEN=OFF /opt/dockerized-norlab-project-mock"
+  refute_output --regexp .*"\[".*"DN-mock".*"\]".*"Execute".*"cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -D PROJECT_BUILD_TESTS=OFF -D PROJECT_BUILD_DOXYGEN=OFF -D CMAKE_INSTALL_PREFIX=/opt/opt/dockerized-norlab-project-mock"
+
+  assert_output --regexp .*"\[".*"DN-mock done".*"\]".*"dockerized-norlab-project-mock installed successfully at".*
+}
+
+@test "Mock Project | run ${TESTED_FILE} (default) (read APPEND_TO_CMAKE_FLAG ok) › expect pass" {
+#  skip "tmp debug" # ToDo: on task end >> delete this line ←
+  cd "${BATS_DOCKER_WORKDIR}"
+
+  export APPEND_TO_CMAKE_FLAG=( -D CMAKE_INSTALL_PREFIX=/opt/test_dir )
+  run source "./${TESTED_FILE_PATH}/$TESTED_FILE" --test-run
+
+  assert_success
+
+  assert_output --regexp .*"\[".*"DN-mock".*"\]".*"Install dockerized-norlab-project-mock"
+
+  assert_output --regexp .*"\[".*"DN-mock".*"\]".*"Execute".*"cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -D PROJECT_BUILD_TESTS=OFF -D PROJECT_BUILD_DOXYGEN=OFF -D CMAKE_INSTALL_PREFIX=/opt/test_dir /opt/dockerized-norlab-project-mock"
+  refute_output --regexp .*"\[".*"DN-mock".*"\]".*"Execute".*"cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -D PROJECT_BUILD_TESTS=OFF -D PROJECT_BUILD_DOXYGEN=OFF /opt/dockerized-norlab-project-mock"
+
+  assert_output --regexp .*"\[".*"DN-mock done".*"\]".*"dockerized-norlab-project-mock installed successfully at".*
+}
+
+
+@test "Mock Project | run ${TESTED_FILE} (argument check) › expect pass" {
+#  skip "tmp debug" # ToDo: on task end >> delete this line ←
+  cd "${BATS_DOCKER_WORKDIR}"
+
+  run bash "./${TESTED_FILE_PATH}/$TESTED_FILE" --test-run \
+             --install-path /opt/test_dir \
+             --repository-version v0.0.1 \
+             --compile-test \
+             --generate-doc \
+             --cmake-build-type Release
+
+  assert_success
+  assert_output --regexp .*"\[".*"DN-mock".*"\]".*"Install dockerized-norlab-project-mock"
+
+  assert_output --partial "switching to 'tags/v0.0.1'."
+
+  assert_output --regexp .*"\[".*"DN-mock".*"\]".*"Repository checkout at tag v0.0.1"
+
+  assert_output --regexp .*"\[".*"DN-mock".*"\]".*"Execute".*"cmake -D CMAKE_BUILD_TYPE=Release -D PROJECT_BUILD_TESTS=ON -D PROJECT_BUILD_DOXYGEN=ON /opt/test_dir/dockerized-norlab-project-mock"
+  refute_output --regexp .*"\[".*"DN-mock".*"\]".*"Execute".*"cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -D PROJECT_BUILD_TESTS=OFF -D PROJECT_BUILD_DOXYGEN=OFF /opt/dockerized-norlab-project-mock"
+
+
+  assert_output --regexp .*"\[".*"DN-mock done".*"\]".*"dockerized-norlab-project-mock installed successfully at".*
+
+}


### PR DESCRIPTION
# Description
### Summary:

Added necessary logic to dockerfile and docker compose template to be able to publish release to docker hub.
Also added cmake installer template with test




### Changes and type of changes (quick overview):

- NMO-467  feat: add docker hub release logic


---

# Checklist:

### Code related
- [ ] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

### PR description related 
- [x] I have included a quick summary of the changes
- [x] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_
