### PR TITLE
fix NBS_MATRIX_ variable must not be overwritten by the declare command


### DIFF
--- a/build_system_templates/.env.build_matrix.dependencies.template
+++ b/build_system_templates/.env.build_matrix.dependencies.template
@@ -12,7 +12,7 @@ NBS_EXECUTE_BUILD_MATRIX_OVER_COMPOSE_FILE=docker-compose.dependencies.yaml
 # Superproject version
 #
 # 'latest' is the latest push to the repository master branch
-#NBS_MATRIX_REPOSITORY_VERSIONS=( 'latest' 'v2.0.test' )
+#NBS_MATRIX_REPOSITORY_VERSIONS=( 'latest' 'v0.0.1' )
 NBS_MATRIX_REPOSITORY_VERSIONS=( 'latest' )
 
 #

--- a/build_system_templates/.env.build_matrix.project.template
+++ b/build_system_templates/.env.build_matrix.project.template
@@ -12,7 +12,7 @@ NBS_EXECUTE_BUILD_MATRIX_OVER_COMPOSE_FILE=docker-compose.project_core.yaml
 # Superproject version
 #
 # 'latest' is the latest push to the repository master branch
-#NBS_MATRIX_REPOSITORY_VERSIONS=( 'latest' 'v2.0.test' )
+#NBS_MATRIX_REPOSITORY_VERSIONS=( 'latest' 'v0.0.1' )
 NBS_MATRIX_REPOSITORY_VERSIONS=( 'latest' )
 
 #

--- a/src/utility_scripts/nbs_execute_compose_over_build_matrix.bash
+++ b/src/utility_scripts/nbs_execute_compose_over_build_matrix.bash
@@ -216,11 +216,11 @@ print_msg "Build images specified in ${MSG_DIMMED_FORMAT}'${NBS_EXECUTE_BUILD_MA
 
 # Freeze build matrix env variable to prevent accidental override
 # Note: declare -r ==> set as read-only, declare -a  ==> set as an array
-declare -ra NBS_MATRIX_REPOSITORY_VERSIONS
-declare -ra NBS_MATRIX_CMAKE_BUILD_TYPE
-declare -ra NBS_MATRIX_SUPPORTED_OS
-declare -ra NBS_MATRIX_UBUNTU_SUPPORTED_VERSIONS
-declare -ra NBS_MATRIX_OSX_SUPPORTED_VERSIONS
+declare -ra NBS_MATRIX_REPOSITORY_VERSIONS=(${NBS_MATRIX_REPOSITORY_VERSIONS[@]})
+declare -ra NBS_MATRIX_CMAKE_BUILD_TYPE=(${NBS_MATRIX_CMAKE_BUILD_TYPE[@]})
+declare -ra NBS_MATRIX_SUPPORTED_OS=(${NBS_MATRIX_SUPPORTED_OS[@]})
+declare -ra NBS_MATRIX_UBUNTU_SUPPORTED_VERSIONS=(${NBS_MATRIX_UBUNTU_SUPPORTED_VERSIONS[@]})
+declare -ra NBS_MATRIX_OSX_SUPPORTED_VERSIONS=(${NBS_MATRIX_OSX_SUPPORTED_VERSIONS[@]})
 
 print_msg "Environment variables ${MSG_EMPH_FORMAT}(build matrix)${MSG_END_FORMAT} set for compose:\n
 ${MSG_DIMMED_FORMAT}    NBS_MATRIX_REPOSITORY_VERSIONS=(${NBS_MATRIX_REPOSITORY_VERSIONS[*]}) ${MSG_END_FORMAT}

--- a/tests/tests_bats/tests_utility_script/test_execute_compose_over_build_matrix.bats
+++ b/tests/tests_bats/tests_utility_script/test_execute_compose_over_build_matrix.bats
@@ -92,6 +92,16 @@ function setup_dotenv_build_matrix_superproject() {
   assert_output --regexp "\[NBS done\]".*"FINAL › Build matrix completed with command".*"Completed".*"${TESTED_FILE}".*
 }
 
+# ....Dotenv related...............................................................................
+@test "${TESTED_FILE} › env var from dotenv file exported › expect pass" {
+
+  setup_dotenv_build_matrix_dependencies
+
+  run bash "${TESTED_FILE}" "${DOTENV_BUILD_MATRIX}" --fail-fast -- config --quiet
+  assert_output --regexp .*"\[NBS\]".*"Environment variables".*"(build matrix)".*"set for compose:".*"NBS_MATRIX_REPOSITORY_VERSIONS=\(latest\)".*"NBS_MATRIX_UBUNTU_SUPPORTED_VERSIONS=\(bionic focal jammy\)"
+
+}
+
 # ....Flag related tests...........................................................................
 @test "${TESTED_FILE} › flags are passed across script and function as expected › expect pass" {
 


### PR DESCRIPTION
# Description
### Summary:

Fix problem that could occur when NBS_MATRIX_REPOSITORY_VERSIONS,  NBS_MATRIX_CMAKE_BUILD_TYPE,  NBS_MATRIX_SUPPORTED_OS,  NBS_MATRIX_UBUNTU_SUPPORTED_VERSIONS and NBS_MATRIX_OSX_SUPPORTED_VERSIONS get overwritten by the declare -ra command



---

# Checklist:

### Code related
- [ ] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

### PR description related 
- [x] I have included a quick summary of the changes
- [x] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_
