### PR TITLE
fix import NBS error

### DIFF
--- a/import_norlab_build_system_lib.bash
+++ b/import_norlab_build_system_lib.bash
@@ -52,6 +52,9 @@ function nbs::source_lib(){
       source "${each_file}"
   done
 
+  # Set reference that the NBS library was imported with this script
+  export NBS_IMPORTED=true
+
   # ====Teardown===================================================================================
   cd "${TMP_CWD}"
 }

--- a/src/utility_scripts/nbs_execute_compose_over_build_matrix.bash
+++ b/src/utility_scripts/nbs_execute_compose_over_build_matrix.bash
@@ -4,7 +4,7 @@
 #
 # Usage:
 #   $ cd <path/to>/norlab-build-system/src/utility_scripts/
-#   $ bash nbs_execute_compose_over_build_matrix.bash [--help] <.env.build_matrix.*> [<optional flag>] [-- <any docker cmd+arg>]
+#   $ [bash|source] nbs_execute_compose_over_build_matrix.bash [--help] <.env.build_matrix.*> [<optional flag>] [-- <any docker cmd+arg>]
 #
 #  e.g.:
 #   $ bash nbs_execute_compose_over_build_matrix.bash ".env.build_matrix" -- build --dry-run
@@ -44,22 +44,40 @@
 #set -v
 #set -x
 
+MSG_ERROR_FORMAT="\033[1;31m"
+MSG_DIMMED_FORMAT="\033[1;2m"
+MSG_END_FORMAT="\033[0m"
+
+
 # ....Pre-condition................................................................................
 if [[ "$(basename "$(pwd)")" != "utility_scripts" ]]; then
-  echo -e "\n[\033[1;31mERROR\033[0m] 'nbs_execute_compose_over_build_matrix.bash' script must be executed from the 'norlab-build-system/src/utility_scripts/' directory!\n Curent working directory is '$(pwd)'" 1>&2
-  echo '(press any key to exit)'
-  read -r -n 1
+  echo -e "\n${MSG_ERROR_FORMAT}[ERROR]${MSG_END_FORMAT} 'nbs_execute_compose_over_build_matrix.bash' script must be executed from the 'norlab-build-system/src/utility_scripts/' directory!\n Curent working directory is '$(pwd)'" 1>&2
   exit 1
 fi
 
-# ....path resolution logic........................................................................
-SCRIPT_PATH="$(realpath "$0")"
-NBS_PATH="$(dirname "${SCRIPT_PATH}")/../.."
+if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
+  # This script is being run, ie: __name__="__main__"
+
+  # ....Helper function............................................................................
+  # import shell functions from utilities library
+  SCRIPT_PATH="$(realpath "$0")"
+  NBS_PATH="$(dirname "${SCRIPT_PATH}")/../.."
+  source "${NBS_PATH}/import_norlab_build_system_lib.bash" || exit 1
+
+else
+  # This script is being sourced, ie: __name__="__source__"
+
+  if [[ "${NBS_IMPORTED}" != "true" ]]; then
+    echo -e "\n${MSG_ERROR_FORMAT}[ERROR]${MSG_END_FORMAT} You need to execute ${MSG_DIMMED_FORMAT}import_norlab_build_system_lib.bash${MSG_END_FORMAT} before sourcing ${MSG_DIMMED_FORMAT}nbs_execute_compose_over_build_matrix.bash${MSG_END_FORMAT} otherwise run it with bash." 1>&2
+    exit 1
+  else
+    # NBS was imported prior to the script execution
+    :
+  fi
+
+fi
 
 
-# ....Helper function..............................................................................
-# import shell functions from utilities library
-source "${NBS_PATH}/import_norlab_build_system_lib.bash"
 
 # ....Default......................................................................................
 DOCKER_COMPOSE_CMD_ARGS='build --dry-run'

--- a/tests/tests_bats/tests_utility_script/test_nbs_install_python_dev_tools.bats
+++ b/tests/tests_bats/tests_utility_script/test_nbs_install_python_dev_tools.bats
@@ -64,7 +64,7 @@ teardown() {
 
 # ====Test casses==================================================================================
 
-@test "sourcing $TESTED_FILE from bad cwd › expect fail" {
+@test "Executing $TESTED_FILE from bad cwd › expect fail" {
   cd "${BATS_DOCKER_WORKDIR}/src/"
   # Note:
   #  - "echo 'Y'" is for sending an keyboard input to the 'read' command which expect a single character
@@ -75,7 +75,7 @@ teardown() {
   assert_output --regexp  .*"\[".*"ERROR".*"\]".*"'nbs_install_python_dev_tools.bash' script must be executed from the"
 }
 
-@test "sourcing $TESTED_FILE from ok cwd › expect pass" {
+@test "executing $TESTED_FILE from ok cwd › expect pass" {
   cd "${BATS_DOCKER_WORKDIR}/${TESTED_FILE_PATH}"
   run bash -c "bash ./$TESTED_FILE"
   assert_success


### PR DESCRIPTION
# Description
### Summary:
Fix an error caused when the cript was sourced without having NBS imported first

[issue NMO-480]




### Changes and type of changes (quick overview):

- fix: import_norlab_build_system_lib.bash: No such file or directory 
- Added a ref env variable set by the NBS import script


---

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

### PR description related 
- [x] I have included a quick summary of the changes
- [x] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_
