### PR TITLE
fix: stabilize exit code propagation on crash cases [NMO-509]

### DIFF
--- a/src/function_library/build_tools/execute_compose.bash
+++ b/src/function_library/build_tools/execute_compose.bash
@@ -35,6 +35,12 @@
 #   Dont use "set -e" in this script as it will affect the build system policy, use the --fail-fast flag instead
 #
 
+# Variable set for export
+declare -x REPOSITORY_VERSION
+declare -x CMAKE_BUILD_TYPE
+declare -x DEPENDENCIES_BASE_IMAGE
+declare -x DEPENDENCIES_BASE_IMAGE_TAG
+declare -x NBS_IMAGE_TAG
 
 function nbs::execute_compose() {
   # ....Default....................................................................................
@@ -43,7 +49,9 @@ function nbs::execute_compose() {
   OS_NAME='ubuntu'
   OS_VERSION='focal'
   DOCKER_COMPOSE_CMD_ARGS='build --dry-run'  # alt: "build --no-cache --push" or "up --build --force-recreate"
-  _CI_TEST=false
+  local _CI_TEST=false
+  local DOCKER_EXIT_CODE=1
+  local MAIN_DOCKER_EXIT_CODE=1
 
   # ....Project root logic.........................................................................
   local TMP_CWD=$(pwd)
@@ -203,6 +211,7 @@ function nbs::execute_compose() {
   ## docker compose run [OPTIONS] SERVICE [COMMAND] [ARGS...]
 
   show_and_execute_docker "compose -f ${_COMPOSE_FILE} ${DOCKER_COMPOSE_CMD_ARGS}" "$_CI_TEST"
+  MAIN_DOCKER_EXIT_CODE="${DOCKER_EXIT_CODE:?"variable was not set by n2st::show_and_execute_docker"}"
 
 
   print_msg "Environment variables used by compose:\n
@@ -215,5 +224,5 @@ function nbs::execute_compose() {
   # ====Teardown===================================================================================
   cd "${TMP_CWD}"
 
-  return "${DOCKER_EXIT_CODE:?"variable was not set by n2st::show_and_execute_docker"}"
+  return "${MAIN_DOCKER_EXIT_CODE:?"variable was not set by n2st::show_and_execute_docker"}"
 }

--- a/src/utility_scripts/nbs_execute_compose_over_build_matrix.bash
+++ b/src/utility_scripts/nbs_execute_compose_over_build_matrix.bash
@@ -82,6 +82,9 @@ fi
 # ....Default......................................................................................
 DOCKER_COMPOSE_CMD_ARGS='build --dry-run'
 BUILD_STATUS_PASS=0
+COMPOSE_EXIT_CODE=1
+
+
 
 # ....Project root logic...........................................................................
 TMP_CWD=$(pwd)
@@ -296,17 +299,17 @@ for EACH_REPO_VERSION in "${NBS_MATRIX_REPOSITORY_VERSIONS[@]}"; do
                               --os-version "${EACH_OS_VERSION}" \
                               -- "${DOCKER_COMPOSE_CMD_ARGS}"
 
-        DOCKER_EXIT_CODE=$?
+        COMPOSE_EXIT_CODE=$?
 
         # ....Collect image tags exported by nbs::execute_compose............................
-        # Global: Read 'DOCKER_EXIT_CODE' env variable exported by function show_and_execute_docker
-        if [[ ${DOCKER_EXIT_CODE} == 0 ]]; then
+        # Global: Read 'COMPOSE_EXIT_CODE' env variable exported by function show_and_execute_docker
+        if [[ ${COMPOSE_EXIT_CODE} == 0 ]]; then
           MSG_STATUS="${MSG_DONE_FORMAT}Pass ${MSG_DIMMED_FORMAT}›"
           MSG_STATUS_TC_TAG="Pass ›"
         else
           MSG_STATUS="${MSG_ERROR_FORMAT}Fail ${MSG_DIMMED_FORMAT}›"
           MSG_STATUS_TC_TAG="Fail ›"
-          BUILD_STATUS_PASS=$DOCKER_EXIT_CODE
+          BUILD_STATUS_PASS=$COMPOSE_EXIT_CODE
 
           if [[ ${TEAMCITY_VERSION} ]]; then
             # Fail the build › Will appear on the TeamCity Build Results page


### PR DESCRIPTION
# Description
### Summary:

Set docker exit code to default state (ie failling) such that in cases of subshell crash the build matrix will fail

- Youtrack task [NMO-509]


---

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

### PR description related 
- [x] I have included a quick summary of the changes
- [x] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_
