### PR TITLE
Update Test Scripts and Run Configurations

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,9 @@
 # Description
 ### Summary:
 
+Add a quick summary here.  
 
 
-
-
-
-### Changes and type of changes (quick overview):
-
-- 
-- 
-- 
-
-
----
 
 # Checklist:
 
@@ -27,10 +17,6 @@
 ### PR creation related 
 - [ ] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
 - [ ] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)
-
-### PR description related 
-- [ ] I have included a quick summary of the changes
-- [ ] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`
 
  ## Note for repository admins
  ### Release PR related

--- a/.run/[NBS] run_all_docker_build_tests.bash.run.xml
+++ b/.run/[NBS] run_all_docker_build_tests.bash.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="run_all_docker_build_tests.bash" type="ShConfigurationType" folderName="[NBS] docker build tests">
+  <configuration default="false" name="[NBS] run_all_docker_build_tests.bash" type="ShConfigurationType" folderName="[NBS] docker build tests">
     <option name="SCRIPT_TEXT" value="cd tests/ &amp;&amp; bash run_all_docker_build_tests.bash" />
     <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
     <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/run_all_docker_dryrun_and_config_tests.bash" />
@@ -9,7 +9,7 @@
     <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
     <option name="INTERPRETER_PATH" value="/bin/zsh" />
     <option name="INTERPRETER_OPTIONS" value="" />
-    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
     <option name="EXECUTE_SCRIPT_FILE" value="false" />
     <envs>
       <env name="BUILDX_BUILDER" value="local-builder-multiarch-virtual" />

--- a/.run/[NBS] run_all_docker_dryrun_and_config_tests.bash.run.xml
+++ b/.run/[NBS] run_all_docker_dryrun_and_config_tests.bash.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="run_all_docker_dryrun_and_config_tests.bash" type="ShConfigurationType" folderName="[NBS] docker dryrun and config test">
+  <configuration default="false" name="[NBS] run_all_docker_dryrun_and_config_tests.bash" type="ShConfigurationType" folderName="[NBS] docker dryrun and config test">
     <option name="SCRIPT_TEXT" value="cd tests/ &amp;&amp; bash run_all_docker_dryrun_and_config_tests.bash" />
     <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
     <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/run_all_docker_dryrun_and_config_tests.bash" />
@@ -9,7 +9,7 @@
     <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
     <option name="INTERPRETER_PATH" value="/bin/zsh" />
     <option name="INTERPRETER_OPTIONS" value="" />
-    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
     <option name="EXECUTE_SCRIPT_FILE" value="false" />
     <envs>
       <env name="BUILDX_BUILDER" value="local-builder-multiarch-virtual" />

--- a/.run/[NBS] run_bats_core_test_in_n2st.bash (all) .run.xml
+++ b/.run/[NBS] run_bats_core_test_in_n2st.bash (all) .run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="[NBS] run bats tests  › 'tests' (all) " type="ShConfigurationType" folderName="[NBS] bats tests">
+  <configuration default="false" name="[NBS] run_bats_core_test_in_n2st.bash (all) " type="ShConfigurationType" folderName="[NBS] bats tests">
     <option name="SCRIPT_TEXT" value="" />
     <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
     <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/run_bats_core_test_in_n2st.bash" />
@@ -9,7 +9,7 @@
     <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
     <option name="INTERPRETER_PATH" value="/bin/zsh" />
     <option name="INTERPRETER_OPTIONS" value="" />
-    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
     <option name="EXECUTE_SCRIPT_FILE" value="true" />
     <envs>
       <env name="DOCKER_CONTEXT" value="desktop-linux" />

--- a/tests/run_bats_core_test_in_n2st.bash
+++ b/tests/run_bats_core_test_in_n2st.bash
@@ -15,16 +15,17 @@
 # Globals: none
 #
 # =================================================================================================
-PARAMS="$@"
+set -e
 
+# ....Pass argument................................................................................
+PARAMS="$@"
 if [[ -z $PARAMS ]]; then
   # Set to default bats tests directory if none specified
   PARAMS="tests/"
 fi
 
 function nbs::run_n2st_testsing_tools(){
-  local TMP_CWD
-  TMP_CWD=$(pwd)
+  pushd "$(pwd)" >/dev/null || exit 1
 
   # ....Project root logic.........................................................................
   NBS_PATH=$(git rev-parse --show-toplevel)
@@ -37,7 +38,8 @@ function nbs::run_n2st_testsing_tools(){
   bash "${N2ST_PATH}/tests/bats_testing_tools/run_bats_tests_in_docker.bash" $PARAMS
 
   # ....Teardown...................................................................................
-  cd "$TMP_CWD"
+  popd >/dev/null || exit 1
   }
 
+# ::::Main:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 nbs::run_n2st_testsing_tools


### PR DESCRIPTION
# Description
### Summary:

- Add `set -e` to scripts for reliable error handling.
- Switch to `pushd/popd` for safe nested script directory manipulations.
- Run configuration files have been renamed for better clarity.
- Execution settings now enable running scripts directly in the terminal.
---

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

### PR description related 
- [x] I have included a quick summary of the changes
- [x] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_
