### PR TITLE
Update N2ST submodule and improve script error handling

### DIFF
--- a/src/utility_scripts/nbs_run_all_test_and_dryrun_in_directory.bash
+++ b/src/utility_scripts/nbs_run_all_test_and_dryrun_in_directory.bash
@@ -16,6 +16,7 @@ SCRIPT_DIR_PATH="${1:?'[ERROR] Missing mandatory path to directory to run script
 
 MSG_DIMMED_FORMAT="\033[1;2m"
 MSG_ERROR_FORMAT="\033[1;31m"
+MSG_DONE_FORMAT="\033[1;32m"
 MSG_END_FORMAT="\033[0m"
 
 function nbs::run_all_script_in_directory(){
@@ -35,9 +36,11 @@ function nbs::run_all_script_in_directory(){
     if [[ -f $each_file ]]; then
       bash "${each_file}"
       EXIT_CODE=$?
-      FILE_NAME+=( "   exit code $EXIT_CODE ‹ $( basename "${each_file}" )")
       if [[ ${EXIT_CODE} != 0 ]]; then
+          FILE_NAME+=( "${MSG_ERROR_FORMAT}   exit code $EXIT_CODE ‹ $( basename "${each_file}" )${MSG_END_FORMAT}")
           OVERALL_EXIT_CODE=${EXIT_CODE}
+      else
+        FILE_NAME+=( "${MSG_DONE_FORMAT}   exit code $EXIT_CODE ‹ $( basename "${each_file}" )${MSG_END_FORMAT}")
       fi
     fi
   done
@@ -47,9 +50,11 @@ function nbs::run_all_script_in_directory(){
     if [[ -f $each_file ]]; then
       bash "${each_file}"
       EXIT_CODE=$?
-      FILE_NAME+=( "   exit code $EXIT_CODE ‹ $( basename "${each_file}" )")
       if [[ ${EXIT_CODE} != 0 ]]; then
+          FILE_NAME+=( "${MSG_ERROR_FORMAT}   exit code $EXIT_CODE ‹ $( basename "${each_file}" )${MSG_END_FORMAT}")
           OVERALL_EXIT_CODE=${EXIT_CODE}
+      else
+        FILE_NAME+=( "${MSG_DONE_FORMAT}   exit code $EXIT_CODE ‹ $( basename "${each_file}" )${MSG_END_FORMAT}")
       fi
     fi
   done

--- a/src/utility_scripts/nbs_run_all_test_and_dryrun_in_directory.bash
+++ b/src/utility_scripts/nbs_run_all_test_and_dryrun_in_directory.bash
@@ -12,8 +12,6 @@
 #
 
 
-
-
 SCRIPT_DIR_PATH="${1:?'[ERROR] Missing mandatory path to directory to run script'}"
 
 MSG_DIMMED_FORMAT="\033[1;2m"
@@ -56,13 +54,17 @@ function nbs::run_all_script_in_directory(){
     fi
   done
 
+
+  # ....Show result................................................................................
+  clear
+
   echo -e "Results from ${MSG_DIMMED_FORMAT}$0${MSG_END_FORMAT} in directory ${MSG_DIMMED_FORMAT}$( basename "${SCRIPT_DIR_PATH}" )/${MSG_END_FORMAT} \n"
   for each_file_run in "${FILE_NAME[@]}" ; do
       echo "$each_file_run"
   done
 
   # ====Teardown===================================================================================
-  cd "${_TMP_CWD}"
+  cd "${_TMP_CWD}" || exit 1
 
   return $OVERALL_EXIT_CODE
 }


### PR DESCRIPTION
# Description
### Summary:

- Updated the N2ST submodule to the latest version for compatibility improvements.
- Enhanced user experience and robustness of `nbs_run_all_test_and_dryrun_in_directory.bash`:
    - Added a `clear` command for improved output clarity.
    - Implemented error handling for `cd` commands to fail gracefully (`|| exit 1`).
    - Improved readability by removing unnecessary blank lines from the script.

# Checklist:

### Code related
- [ ] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [ ] I have commented hard-to-understand code 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_