### PR TITLE
Fix tests script launcher

### DIFF
--- a/import_norlab_build_system_lib.bash
+++ b/import_norlab_build_system_lib.bash
@@ -14,7 +14,7 @@ MSG_END_FORMAT="\033[0m"
 function nbs::source_lib(){
 
   # ....Setup......................................................................................
-  local debug_log=false
+  local debug_flag=false
   local tmp_cwd
   tmp_cwd=$(pwd)
   local script_path
@@ -34,7 +34,7 @@ function nbs::source_lib(){
       target_path="$(dirname "${script_path}")"
     fi
 
-    if [[ ${debug_log} == true ]]; then
+    if [[ ${debug_flag} == true ]]; then
       echo "
       BASH_SOURCE: ${BASH_SOURCE[*]}
 

--- a/tests/run_all_docker_build_tests.bash
+++ b/tests/run_all_docker_build_tests.bash
@@ -1,15 +1,18 @@
 #!/bin/bash
-#
-# Run all tests in directory
+# =================================================================================================
+# Run all tests in 'tests/tests_docker_build' directory
 #
 # Usage:
 #   $ bash run_all_docker_build_tests.bash
 #
-#
+# =================================================================================================
+test_dir="tests/tests_docker_build"
 
-_PATH_TO_SCRIPT="$(realpath "$0")"
-SCRIPT_DIR_PATH="$(dirname "${_PATH_TO_SCRIPT}")"
-TEST_DIR="$SCRIPT_DIR_PATH/tests_docker_build"
+# ....Setup........................................................................................
+path_to_script="$(realpath "$0")"
+script_dir_path="$(dirname "${path_to_script}")"
+NBS_PATH="$( realpath -q "${script_dir_path}/.." )"
 
-source "${SCRIPT_DIR_PATH}/../src/utility_scripts/nbs_run_all_test_and_dryrun_in_directory.bash" "${TEST_DIR}"
-
+# ....Begin........................................................................................
+source "${NBS_PATH:?err}/src/utility_scripts/nbs_run_all_test_and_dryrun_in_directory.bash" "${NBS_PATH}/${test_dir}"
+exit $?

--- a/tests/run_all_docker_dryrun_and_config_tests.bash
+++ b/tests/run_all_docker_dryrun_and_config_tests.bash
@@ -1,15 +1,18 @@
 #!/bin/bash
 # =================================================================================================
-# Run all tests in directory
+# Run all tests in 'tests/tests_docker_dryrun_and_config' directory
 #
 # Usage:
 #   $ bash run_all_docker_dryrun_and_config_tests.bash
 #
 # =================================================================================================
+test_dir="tests/tests_docker_dryrun_and_config"
 
+# ....Setup........................................................................................
 path_to_script="$(realpath "$0")"
 script_dir_path="$(dirname "${path_to_script}")"
-test_dir="$script_dir_path/tests_docker_dryrun_and_config"
+NBS_PATH="$( realpath -q "${script_dir_path}/.." )"
 
-source "${script_dir_path}/../src/utility_scripts/nbs_run_all_test_and_dryrun_in_directory.bash" "${test_dir}"
-
+# ....Begin........................................................................................
+source "${NBS_PATH:?err}/src/utility_scripts/nbs_run_all_test_and_dryrun_in_directory.bash" "${NBS_PATH}/${test_dir}"
+exit $?


### PR DESCRIPTION

fix: rename variables and improve test script structure

- Renamed `debug_log` to `debug_flag` for clearer naming consistency.
- Updated test scripts to define `test_dir` explicitly and utilize a unified `NBS_PATH` variable.
- Enhanced comments and formatting for better readability and maintainability.
- Update N2ST to latest release.