### PR TITLE
Fix incorrect fallback value for exit_code variable

### DIFF
--- a/tests/run_bats_core_test_in_n2st.bash
+++ b/tests/run_bats_core_test_in_n2st.bash
@@ -40,7 +40,7 @@ function n2st::teardown() {
   exit_code=$?
   cd "${superproject_path:?err}" || exit 1
   # Add any teardown logic here
-  exit ${exit_code:1}
+  exit ${exit_code:-1}
 }
 trap n2st::teardown EXIT
 


### PR DESCRIPTION
# Description
### Summary:

Fixed a typo in the script's teardown function that caused the fallback value of `exit_code` to be incorrect. Updated `${exit_code:1}` to `${exit_code:-1}` to ensure the script exits with a proper default status of `-1` when `exit_code` is undefined. Also updated N2ST to the latest release.  
